### PR TITLE
Update Temporalio packages to 1.9.0 and migrate target framework to .NET 10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <!-- Solution Commons -->
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -91,10 +91,10 @@
     <PackageVersion Include="System.ServiceModel.Primitives" Version="8.1.2"/>
     <PackageVersion Include="System.ServiceModel.UnixDomainSocket" Version="8.1.2"/>
     <PackageVersion Include="System.Web.Services.Description" Version="8.1.2"/>
-    <PackageVersion Include="Temporalio" Version="1.7.0"/>
-    <PackageVersion Include="Temporalio.Extensions.Hosting" Version="1.7.0"/>
-    <PackageVersion Include="Temporalio.Extensions.DiagnosticSource" Version="1.7.0"/>
-    <PackageVersion Include="Temporalio.Extensions.OpenTelemetry" Version="1.7.0"/>
+    <PackageVersion Include="Temporalio" Version="1.9.0"/>
+    <PackageVersion Include="Temporalio.Extensions.Hosting" Version="1.9.0"/>
+    <PackageVersion Include="Temporalio.Extensions.DiagnosticSource" Version="1.9.0"/>
+    <PackageVersion Include="Temporalio.Extensions.OpenTelemetry" Version="1.9.0"/>
     <PackageVersion Include="xunit.v3" Version="3.0.0"/>
     <PackageVersion Include="xunit.analyzers" Version="1.23.0"/>
     <PackageVersion Include="xunit.categories" Version="3.0.1"/>

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "version": "10.0.100",
-    "rollForward": "latestMajor",
+    "rollForward": "latestFeature",
     "allowPrerelease": false
   }
 }

--- a/src/Workflows/Escendit.Extensions.Workflows.csproj
+++ b/src/Workflows/Escendit.Extensions.Workflows.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Temporalio.Extensions.Hosting"/>
     <PackageReference Include="Temporalio.Extensions.OpenTelemetry"/>
   </ItemGroup>

--- a/src/Workflows/PublicAPI.Unshipped.txt
+++ b/src/Workflows/PublicAPI.Unshipped.txt
@@ -1,13 +1,15 @@
-const Microsoft.Extensions.DependencyInjection.TemporalDefaults.ClientNamespace = "default" -> string!
-const Microsoft.Extensions.DependencyInjection.TemporalDefaults.ClientTargetHost = "localhost:7233" -> string!
 Microsoft.Extensions.DependencyInjection.ITemporalBuilder
-Microsoft.Extensions.DependencyInjection.ITemporalBuilder.Name.get -> string!
-Microsoft.Extensions.DependencyInjection.ITemporalBuilder.Services.get -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
 Microsoft.Extensions.DependencyInjection.ServiceCollectionExtensions
+Microsoft.Extensions.DependencyInjection.ServiceCollectionExtensions.extension(Microsoft.Extensions.DependencyInjection.IServiceCollection)
 Microsoft.Extensions.DependencyInjection.TemporalBuilderExtensions
+Microsoft.Extensions.DependencyInjection.TemporalBuilderExtensions.extension(Microsoft.Extensions.DependencyInjection.ITemporalBuilder)
 Microsoft.Extensions.DependencyInjection.TemporalDefaults
-static Microsoft.Extensions.DependencyInjection.ServiceCollectionExtensions.AddKeyedTemporalClient(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, string! taskQueue, string? clientTargetHost = null, string? clientNamespace = null) -> Microsoft.Extensions.Options.OptionsBuilder<Temporalio.Client.TemporalClientConnectOptions!>!
-static Microsoft.Extensions.DependencyInjection.ServiceCollectionExtensions.AddTemporalHostedService(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, string! taskQueue, string! clientTargetHost = "localhost:7233", string! clientNamespace = "default", string? buildId = null) -> Microsoft.Extensions.DependencyInjection.ITemporalBuilder!
-static Microsoft.Extensions.DependencyInjection.TemporalBuilderExtensions.ConfigureClientOptions(this Microsoft.Extensions.DependencyInjection.ITemporalBuilder! temporalBuilder, System.Action<Microsoft.Extensions.Options.OptionsBuilder<Temporalio.Client.TemporalClientConnectOptions!>!>! configureOptions) -> Microsoft.Extensions.DependencyInjection.ITemporalBuilder!
-static Microsoft.Extensions.DependencyInjection.TemporalBuilderExtensions.ConfigureClientOptions(this Microsoft.Extensions.DependencyInjection.ITemporalBuilder! temporalBuilder, System.Action<Temporalio.Client.TemporalClientConnectOptions!>! configureOptions) -> Microsoft.Extensions.DependencyInjection.ITemporalBuilder!
-static Microsoft.Extensions.DependencyInjection.TemporalBuilderExtensions.ConfigureWorkerOptions(this Microsoft.Extensions.DependencyInjection.ITemporalBuilder! temporalBuilder, System.Action<Temporalio.Extensions.Hosting.ITemporalWorkerServiceOptionsBuilder!>! configureOptions) -> Microsoft.Extensions.DependencyInjection.ITemporalBuilder!
+~const Microsoft.Extensions.DependencyInjection.TemporalDefaults.ClientNamespace = "default" -> string
+~const Microsoft.Extensions.DependencyInjection.TemporalDefaults.ClientTargetHost = "localhost:7233" -> string
+~Microsoft.Extensions.DependencyInjection.ITemporalBuilder.Name.get -> string
+~Microsoft.Extensions.DependencyInjection.ITemporalBuilder.Services.get -> Microsoft.Extensions.DependencyInjection.IServiceCollection
+~Microsoft.Extensions.DependencyInjection.ServiceCollectionExtensions.extension(Microsoft.Extensions.DependencyInjection.IServiceCollection).AddKeyedTemporalClient(string name, string? clientTargetHost = null, string? clientNamespace = null) -> Microsoft.Extensions.Options.OptionsBuilder<Temporalio.Client.TemporalClientConnectOptions>
+~Microsoft.Extensions.DependencyInjection.ServiceCollectionExtensions.extension(Microsoft.Extensions.DependencyInjection.IServiceCollection).AddTemporalHostedService(string name, string clientTargetHost = "localhost:7233", string clientNamespace = "default", string? buildId = null) -> Microsoft.Extensions.DependencyInjection.ITemporalBuilder
+~Microsoft.Extensions.DependencyInjection.TemporalBuilderExtensions.extension(Microsoft.Extensions.DependencyInjection.ITemporalBuilder).ConfigureClientOptions(System.Action<Microsoft.Extensions.Options.OptionsBuilder<Temporalio.Client.TemporalClientConnectOptions>> configureOptions) -> Microsoft.Extensions.DependencyInjection.ITemporalBuilder
+~Microsoft.Extensions.DependencyInjection.TemporalBuilderExtensions.extension(Microsoft.Extensions.DependencyInjection.ITemporalBuilder).ConfigureClientOptions(System.Action<Temporalio.Client.TemporalClientConnectOptions> configureOptions) -> Microsoft.Extensions.DependencyInjection.ITemporalBuilder
+~Microsoft.Extensions.DependencyInjection.TemporalBuilderExtensions.extension(Microsoft.Extensions.DependencyInjection.ITemporalBuilder).ConfigureWorkerOptions(System.Action<Temporalio.Extensions.Hosting.ITemporalWorkerServiceOptionsBuilder> configureOptions) -> Microsoft.Extensions.DependencyInjection.ITemporalBuilder

--- a/src/Workflows/ServiceCollectionExtensions.cs
+++ b/src/Workflows/ServiceCollectionExtensions.cs
@@ -20,104 +20,107 @@ using Temporalio.Worker;
 public static class ServiceCollectionExtensions
 {
     /// <summary>
-    /// Add Temporal Hosted Service.
+    /// Provides extension methods for configuring and adding Temporal services to an <see cref="IServiceCollection"/>.
     /// </summary>
-    /// <param name="services">The initial <see cref="IServiceCollection"/>.</param>
-    /// <param name="taskQueue">The task queue name.</param>
-    /// <param name="clientTargetHost">The client target host.</param>
-    /// <param name="clientNamespace">The client namespace.</param>
-    /// <param name="buildId">The build id.</param>
-    /// <returns>The updated <see cref="IServiceCollection"/>.</returns>
-    public static ITemporalBuilder AddTemporalHostedService(
-        this IServiceCollection services,
-        string taskQueue,
-        string clientTargetHost = TemporalDefaults.ClientTargetHost,
-        string clientNamespace = TemporalDefaults.ClientNamespace,
-        string? buildId = null)
+    extension(IServiceCollection services)
     {
-        ArgumentNullException.ThrowIfNull(services);
-        ArgumentNullException.ThrowIfNull(taskQueue);
-        var clientOptionsBuilder = services
-            .AddKeyedTemporalClient(taskQueue, clientTargetHost, clientNamespace)
-            .Configure(options =>
-            {
-                var serializerOptions = new JsonSerializerOptions();
-                options.DataConverter = new DataConverter(new DefaultPayloadConverter(serializerOptions), new DefaultFailureConverter());
-                options.Interceptors = [new TracingInterceptor()];
-            });
-
-        var workerOptionsBuilder = services
-            .AddHostedTemporalWorker(clientTargetHost, clientNamespace, taskQueue, new WorkerDeploymentOptions
-            {
-                UseWorkerVersioning = buildId is not null,
-                DefaultVersioningBehavior = VersioningBehavior.Unspecified,
-                Version = buildId is null
-                    ? null
-                    : new WorkerDeploymentVersion(taskQueue, buildId),
-            })
-            .ConfigureOptions(
-                options =>
+        /// <summary>
+        /// Add Temporal Hosted Service.
+        /// </summary>
+        /// <param name="name">The task queue name.</param>
+        /// <param name="clientTargetHost">The client target host.</param>
+        /// <param name="clientNamespace">The client namespace.</param>
+        /// <param name="buildId">The build id.</param>
+        /// <returns>The updated <see cref="IServiceCollection"/>.</returns>
+        public ITemporalBuilder AddTemporalHostedService(
+            string name,
+            string clientTargetHost = TemporalDefaults.ClientTargetHost,
+            string clientNamespace = TemporalDefaults.ClientNamespace,
+            string? buildId = null)
+        {
+            ArgumentNullException.ThrowIfNull(services);
+            ArgumentNullException.ThrowIfNull(name);
+            var clientOptionsBuilder = services
+                .AddKeyedTemporalClient(name, clientTargetHost, clientNamespace)
+                .Configure(options =>
                 {
                     var serializerOptions = new JsonSerializerOptions();
-
+                    options.DataConverter = new DataConverter(new DefaultPayloadConverter(serializerOptions), new DefaultFailureConverter());
                     options.Interceptors = [new TracingInterceptor()];
+                });
 
-                    if (options.ClientOptions is null)
-                    {
-                        return;
-                    }
-
-                    options.ClientOptions.DataConverter = new DataConverter(new DefaultPayloadConverter(serializerOptions), new DefaultFailureConverter());
-                    options.ClientOptions.Interceptors = [new TracingInterceptor()];
-                },
-                disallowDuplicates: true);
-
-        return new TemporalBuilder(taskQueue, services, clientOptionsBuilder, workerOptionsBuilder);
-    }
-
-    /// <summary>
-    /// Add Keyed Temporal Client.
-    /// </summary>
-    /// <param name="services">The initial service collection.</param>
-    /// <param name="taskQueue">The task queue.</param>
-    /// <param name="clientTargetHost">The client target host.</param>
-    /// <param name="clientNamespace">The client namespace.</param>
-    /// <returns>The updated service collection.</returns>
-    /// <exception cref="ArgumentException">Throws exception when service key is invalid type.</exception>
-    public static OptionsBuilder<TemporalClientConnectOptions> AddKeyedTemporalClient(
-        this IServiceCollection services,
-        string taskQueue,
-        string? clientTargetHost = null,
-        string? clientNamespace = null)
-    {
-        ArgumentNullException.ThrowIfNull(services);
-
-        services.TryAddKeyedSingleton<ITemporalClient>(taskQueue, (serviceProvider, _) =>
-            TemporalClient.CreateLazy(serviceProvider.GetRequiredService<IOptionsMonitor<TemporalClientConnectOptions>>().Get(taskQueue)));
-
-        var builder = services.AddOptions<TemporalClientConnectOptions>(taskQueue);
-
-        if (clientTargetHost is not null || clientNamespace is not null)
-        {
-            builder.Configure(options =>
-            {
-                options.TargetHost = clientTargetHost;
-
-                if (clientNamespace is not null)
+            var workerOptionsBuilder = services
+                .AddHostedTemporalWorker(clientTargetHost, clientNamespace, name, new WorkerDeploymentOptions
                 {
-                    options.Namespace = clientNamespace;
-                }
-            });
+                    UseWorkerVersioning = buildId is not null,
+                    DefaultVersioningBehavior = VersioningBehavior.Unspecified,
+                    Version = buildId is null
+                        ? null
+                        : new WorkerDeploymentVersion(name, buildId),
+                })
+                .ConfigureOptions(
+                    options =>
+                    {
+                        var serializerOptions = new JsonSerializerOptions();
+
+                        options.Interceptors = [new TracingInterceptor()];
+
+                        if (options.ClientOptions is null)
+                        {
+                            return;
+                        }
+
+                        options.ClientOptions.DataConverter = new DataConverter(new DefaultPayloadConverter(serializerOptions), new DefaultFailureConverter());
+                        options.ClientOptions.Interceptors = [new TracingInterceptor()];
+                    },
+                    disallowDuplicates: true);
+
+            return new TemporalBuilder(name, services, clientOptionsBuilder, workerOptionsBuilder);
         }
 
-        builder.Configure<IServiceProvider>((options, provider) =>
+        /// <summary>
+        /// Add Keyed Temporal Client.
+        /// </summary>
+        /// <param name="name">The name.</param>
+        /// <param name="clientTargetHost">The client target host.</param>
+        /// <param name="clientNamespace">The client namespace.</param>
+        /// <returns>The updated service collection.</returns>
+        /// <exception cref="ArgumentException">Throws exception when service key is invalid type.</exception>
+        public OptionsBuilder<TemporalClientConnectOptions> AddKeyedTemporalClient(
+            string name,
+            string? clientTargetHost = null,
+            string? clientNamespace = null)
         {
-            if (provider.GetService<ILoggerFactory>() is { } loggerFactory)
-            {
-                options.LoggerFactory = loggerFactory;
-            }
-        });
+            ArgumentNullException.ThrowIfNull(services);
+            ArgumentNullException.ThrowIfNull(name);
 
-        return builder;
+            services.TryAddKeyedSingleton<ITemporalClient>(name, (serviceProvider, _) =>
+                TemporalClient.CreateLazy(serviceProvider.GetRequiredService<IOptionsMonitor<TemporalClientConnectOptions>>().Get(name)));
+
+            var builder = services.AddOptions<TemporalClientConnectOptions>(name);
+
+            if (clientTargetHost is not null || clientNamespace is not null)
+            {
+                builder.Configure(options =>
+                {
+                    options.TargetHost = clientTargetHost;
+
+                    if (clientNamespace is not null)
+                    {
+                        options.Namespace = clientNamespace;
+                    }
+                });
+            }
+
+            builder.Configure<IServiceProvider>((options, provider) =>
+            {
+                if (provider.GetService<ILoggerFactory>() is { } loggerFactory)
+                {
+                    options.LoggerFactory = loggerFactory;
+                }
+            });
+
+            return builder;
+        }
     }
 }

--- a/src/Workflows/TemporalBuilderExtensions.cs
+++ b/src/Workflows/TemporalBuilderExtensions.cs
@@ -13,49 +13,49 @@ using Temporalio.Extensions.Hosting;
 public static class TemporalBuilderExtensions
 {
     /// <summary>
-    /// Configure Client Options.
+    /// Provides extension methods for configuring an <see cref="ITemporalBuilder"/> instance.
     /// </summary>
-    /// <param name="temporalBuilder">The initial temporal migrator builder.</param>
-    /// <param name="configureOptions">The configure client options.</param>
-    /// <returns>The updated temporal migrator builder.</returns>
-    public static ITemporalBuilder ConfigureClientOptions(
-        this ITemporalBuilder temporalBuilder,
-        Action<OptionsBuilder<TemporalClientConnectOptions>> configureOptions)
+    extension(ITemporalBuilder temporalBuilder)
     {
-        ArgumentNullException.ThrowIfNull(temporalBuilder);
-        ArgumentNullException.ThrowIfNull(configureOptions);
-        configureOptions.Invoke(temporalBuilder.ClientOptionsBuilder);
-        return temporalBuilder;
-    }
+        /// <summary>
+        /// Configure Client Options.
+        /// </summary>
+        /// <param name="configureOptions">The configure client options.</param>
+        /// <returns>The updated temporal migrator builder.</returns>
+        public ITemporalBuilder ConfigureClientOptions(
+            Action<OptionsBuilder<TemporalClientConnectOptions>> configureOptions)
+        {
+            ArgumentNullException.ThrowIfNull(temporalBuilder);
+            ArgumentNullException.ThrowIfNull(configureOptions);
+            configureOptions.Invoke(temporalBuilder.ClientOptionsBuilder);
+            return temporalBuilder;
+        }
 
-    /// <summary>
-    /// Configure Client Options.
-    /// </summary>
-    /// <param name="temporalBuilder">The initial temporal migrator builder.</param>
-    /// <param name="configureOptions">The configure client options.</param>
-    /// <returns>The updated temporal migrator builder.</returns>
-    public static ITemporalBuilder ConfigureClientOptions(
-        this ITemporalBuilder temporalBuilder,
-        Action<TemporalClientConnectOptions> configureOptions)
-    {
-        ArgumentNullException.ThrowIfNull(temporalBuilder);
-        ArgumentNullException.ThrowIfNull(configureOptions);
-        return ConfigureClientOptions(temporalBuilder, builder => builder.Configure(configureOptions));
-    }
+        /// <summary>
+        /// Configure Client Options.
+        /// </summary>
+        /// <param name="configureOptions">The configure client options.</param>
+        /// <returns>The updated temporal migrator builder.</returns>
+        public ITemporalBuilder ConfigureClientOptions(
+            Action<TemporalClientConnectOptions> configureOptions)
+        {
+            ArgumentNullException.ThrowIfNull(temporalBuilder);
+            ArgumentNullException.ThrowIfNull(configureOptions);
+            return ConfigureClientOptions(temporalBuilder, builder => builder.Configure(configureOptions));
+        }
 
-    /// <summary>
-    /// Configure Worker Options.
-    /// </summary>
-    /// <param name="temporalBuilder">The initial temporal migrator builder.</param>
-    /// <param name="configureOptions">The configure options.</param>
-    /// <returns>The updated temporal migrator builder.</returns>
-    public static ITemporalBuilder ConfigureWorkerOptions(
-        this ITemporalBuilder temporalBuilder,
-        Action<ITemporalWorkerServiceOptionsBuilder> configureOptions)
-    {
-        ArgumentNullException.ThrowIfNull(temporalBuilder);
-        ArgumentNullException.ThrowIfNull(configureOptions);
-        configureOptions.Invoke(temporalBuilder.WorkerOptionsBuilder);
-        return temporalBuilder;
+        /// <summary>
+        /// Configure Worker Options.
+        /// </summary>
+        /// <param name="configureOptions">The configure options.</param>
+        /// <returns>The updated temporal migrator builder.</returns>
+        public ITemporalBuilder ConfigureWorkerOptions(
+            Action<ITemporalWorkerServiceOptionsBuilder> configureOptions)
+        {
+            ArgumentNullException.ThrowIfNull(temporalBuilder);
+            ArgumentNullException.ThrowIfNull(configureOptions);
+            configureOptions.Invoke(temporalBuilder.WorkerOptionsBuilder);
+            return temporalBuilder;
+        }
     }
 }

--- a/src/Workflows/packages.lock.json
+++ b/src/Workflows/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "dependencies": {
-    "net9.0": {
+    "net10.0": {
       "Escendit.Tools.Branding": {
         "type": "Direct",
         "requested": "[1.2.0, )",
@@ -35,6 +35,15 @@
         "resolved": "3.3.4",
         "contentHash": "kNLTfXtXUWDHVt5iaPkkiPuyHYlMgLI6SOFT4w88bfeI2vqSeGgHunFkdvlaCM8RDfcY0t2+jnesQtidRJJ/DA=="
       },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Direct",
+        "requested": "[9.0.8, )",
+        "resolved": "9.0.8",
+        "contentHash": "JJjI2Fa+QtZcUyuNjbKn04OjIUX5IgFGFu/Xc+qvzh1rXdZHLcnqqVXhR4093bGirTwacRlHiVg1XYI9xum6QQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.8"
+        }
+      },
       "Roslynator.Analyzers": {
         "type": "Direct",
         "requested": "[4.14.1, )",
@@ -49,23 +58,22 @@
       },
       "Temporalio.Extensions.Hosting": {
         "type": "Direct",
-        "requested": "[1.7.0, )",
-        "resolved": "1.7.0",
-        "contentHash": "eT1Q1ivxOT5D1mQ+tYRLtVEP41ACHxU+UMleLBPzBVNT0zA9hX1z11/YdlAXrbK1xuzWHSRJU6VKx6btBXxtFQ==",
+        "requested": "[1.9.0, )",
+        "resolved": "1.9.0",
+        "contentHash": "jN9Y1htuM1TnjwcFP3OgH8FTCHJgubWrWB9jMe/Muyaz11qnguxxWrJrMo6I15uQPYTQ2AJ3lLxJ5w+zSOwGlA==",
         "dependencies": {
           "Microsoft.Extensions.Hosting": "8.0.1",
-          "Temporalio": "1.7.0"
+          "Temporalio": "1.9.0"
         }
       },
       "Temporalio.Extensions.OpenTelemetry": {
         "type": "Direct",
-        "requested": "[1.7.0, )",
-        "resolved": "1.7.0",
-        "contentHash": "cU0e6yz7GmgdQfN0/TuZQIDf8R+m7Jv3Ngmgxc7qrToWC73iPPo4to2Q46rfT2UmOpnq0aLAE2ryNlXNoeN6ug==",
+        "requested": "[1.9.0, )",
+        "resolved": "1.9.0",
+        "contentHash": "7KfqCB0oxxLAF72AxEJDXCLWPZKF2ofwjiHBHgx9P1IXn+dQAWlbMXWvPm4ESIm+RwcJQCn35d7fgpCOhRY2ug==",
         "dependencies": {
           "OpenTelemetry.Api": "1.4.0",
-          "System.Diagnostics.DiagnosticSource": "7.0.0",
-          "Temporalio": "1.7.0"
+          "Temporalio": "1.9.0"
         }
       },
       "Google.Protobuf": {
@@ -263,18 +271,15 @@
         "resolved": "8.0.0",
         "contentHash": "bXJEZrW9ny8vjMF1JV253WeLhpEVzFo1lyaZu1vQ4ZxWUlVvknZ/+ftFgVheLubb4eZPSwwxBeqS1JkCOjxd8g=="
       },
+      "NexusRpc": {
+        "type": "Transitive",
+        "resolved": "0.2.0",
+        "contentHash": "IomEdX2Lh+UMnh++XC+NXugfusOAPOOo2i8xogUILqgyfN2r+36HtPONawMt1VJeS8ucBce85AnTK6eeUeU0Vg=="
+      },
       "OpenTelemetry.Api": {
         "type": "Transitive",
         "resolved": "1.4.0",
-        "contentHash": "754QKfiEZ3TNR3lOWS+u15qJYOVMWXhuUy8zjCXtgbaJihCFga3Wm3UZ9ggC5CJiUEjyeR6vw66NBZUxMOPTNQ==",
-        "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "7.0.0"
-        }
-      },
-      "System.Diagnostics.DiagnosticSource": {
-        "type": "Transitive",
-        "resolved": "7.0.0",
-        "contentHash": "9W0ewWDuAyDqS2PigdTxk6jDKonfgscY/hP8hm7VpxYhNHZHKvZTdRckberlFk3VnCmr3xBUyMBut12Q+T2aOw=="
+        "contentHash": "754QKfiEZ3TNR3lOWS+u15qJYOVMWXhuUy8zjCXtgbaJihCFga3Wm3UZ9ggC5CJiUEjyeR6vw66NBZUxMOPTNQ=="
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
@@ -313,20 +318,11 @@
           "Microsoft.Extensions.FileProviders.Abstractions": "8.0.0"
         }
       },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "CentralTransitive",
-        "requested": "[9.0.8, )",
-        "resolved": "8.0.1",
-        "contentHash": "BmANAnR5Xd4Oqw7yQ75xOAYODybZQRzdeNucg7kS5wWKd2PNnMdYtJ2Vciy0QLylRmv42DGl5+AFL9izA6F1Rw==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
-        }
-      },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[9.0.8, )",
-        "resolved": "8.0.2",
-        "contentHash": "3iE7UF7MQkCv1cxzCahz+Y/guQbTqieyxyaWKhrRO91itI9cOKO76OHeQDahqG4MmW5umr3CcCvGmK92lWNlbg=="
+        "resolved": "9.0.8",
+        "contentHash": "xY3lTjj4+ZYmiKIkyWitddrp1uL5uYiweQjqo4BKBw01ZC4HhcfgLghDpPZcUlppgWAFqFy9SgkiYWOMx365pw=="
       },
       "Microsoft.Extensions.Hosting": {
         "type": "CentralTransitive",
@@ -385,12 +381,13 @@
       },
       "Temporalio": {
         "type": "CentralTransitive",
-        "requested": "[1.7.0, )",
-        "resolved": "1.7.0",
-        "contentHash": "XIZa5utarbPj32ocGHX6VTUnYZ0O/2cdCc0/7G+a8Rg8o0CydW59QP6DbrI4LcftFIuhIfFtMb2N+W5brQ01Sw==",
+        "requested": "[1.9.0, )",
+        "resolved": "1.9.0",
+        "contentHash": "BysoHnmFOPSNwkvqlDjdUdXhqt8s/qEBYFGY1kF0Jr74pkuHvfpHBqyBhWrZ02X2qTPYAwkfRqicug765L8sCw==",
         "dependencies": {
           "Google.Protobuf": "3.26.1",
-          "Microsoft.Extensions.Logging.Abstractions": "2.2.0"
+          "Microsoft.Extensions.Logging.Abstractions": "2.2.0",
+          "NexusRpc": "0.2.0"
         }
       }
     }


### PR DESCRIPTION
Closes #94

## Summary by Sourcery

Migrate Temporal workflow extensions to the new extension-type pattern while updating dependencies and build configuration to target .NET 10 and Temporalio 1.9.0.

Enhancements:
- Refactor workflow service and builder extension classes to use the new C# extension-type style, capturing IServiceCollection and ITemporalBuilder instances instead of static extension methods.
- Improve Temporal configuration helpers by validating input names, aligning parameter naming, and centralizing data converter and interceptor setup for clients and workers.

Build:
- Update solution to target .NET 10 and adjust global.json roll-forward policy to "latestFeature".
- Refresh Temporalio and related package versions and lock files to align with Temporalio 1.9.0 and the new target framework.

Documentation:
- Clarify XML documentation comments for Temporal service and builder extensions to better describe their purpose and parameters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated target framework to .NET 10.
  * Upgraded Temporalio packages to version 1.9.0.
  * Added Microsoft.Extensions.DependencyInjection support.
  * Adjusted SDK version resolution behavior.

* **Refactor**
  * Restructured temporal client and worker configuration APIs for improved fluency and usability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->