### PR TITLE
Add disallowDuplicates parameter to TemporalBuilder and refactor WorkerDeploymentOptions handling

### DIFF
--- a/src/Workflows/ServiceCollectionExtensions.cs
+++ b/src/Workflows/ServiceCollectionExtensions.cs
@@ -31,6 +31,7 @@ public static class ServiceCollectionExtensions
         /// <param name="clientTargetHost">The client target host.</param>
         /// <param name="clientNamespace">The client namespace.</param>
         /// <param name="buildId">The build id.</param>
+        /// <param name="disallowDuplicates">Whether to disallow duplicate registrations.</param>
         /// <returns>The updated <see cref="IServiceCollection"/>.</returns>
         public ITemporalBuilder AddTemporalHostedService(
             string name,

--- a/src/Workflows/ServiceCollectionExtensions.cs
+++ b/src/Workflows/ServiceCollectionExtensions.cs
@@ -36,7 +36,8 @@ public static class ServiceCollectionExtensions
             string name,
             string clientTargetHost = TemporalDefaults.ClientTargetHost,
             string clientNamespace = TemporalDefaults.ClientNamespace,
-            string? buildId = null)
+            string? buildId = null,
+            bool disallowDuplicates = false)
         {
             ArgumentNullException.ThrowIfNull(services);
             ArgumentNullException.ThrowIfNull(name);
@@ -49,15 +50,21 @@ public static class ServiceCollectionExtensions
                     options.Interceptors = [new TracingInterceptor()];
                 });
 
-            var workerOptionsBuilder = services
-                .AddHostedTemporalWorker(clientTargetHost, clientNamespace, name, new WorkerDeploymentOptions
+            var deploymentOptions = buildId is null
+                ? null
+                : new WorkerDeploymentOptions
                 {
-                    UseWorkerVersioning = buildId is not null,
+                    UseWorkerVersioning = true,
                     DefaultVersioningBehavior = VersioningBehavior.Unspecified,
-                    Version = buildId is null
-                        ? null
-                        : new WorkerDeploymentVersion(name, buildId),
-                })
+                    Version = new WorkerDeploymentVersion(name, buildId),
+                };
+
+            var workerOptionsBuilder = services
+                .AddHostedTemporalWorker(
+                    clientTargetHost,
+                    clientNamespace,
+                    name,
+                    deploymentOptions)
                 .ConfigureOptions(
                     options =>
                     {
@@ -73,7 +80,7 @@ public static class ServiceCollectionExtensions
                         options.ClientOptions.DataConverter = new DataConverter(new DefaultPayloadConverter(serializerOptions), new DefaultFailureConverter());
                         options.ClientOptions.Interceptors = [new TracingInterceptor()];
                     },
-                    disallowDuplicates: true);
+                    disallowDuplicates);
 
             return new TemporalBuilder(name, services, clientOptionsBuilder, workerOptionsBuilder);
         }


### PR DESCRIPTION
Closes #97

## Summary by Sourcery

Add a configurable duplicate-registration flag to Temporal hosted service setup and simplify worker deployment options initialization based on build IDs.

Enhancements:
- Expose a disallowDuplicates parameter on AddTemporalHostedService to control duplicate Temporal worker registrations.
- Refactor WorkerDeploymentOptions creation to only initialize deployment metadata when a build ID is provided, simplifying versioning configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to control duplicate handling in hosted worker services (opt-in).

* **Enhancements**
  * Improved deployment option handling: when a build identifier is provided, worker versioning information is applied to deployments to better track and manage versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->